### PR TITLE
Initial pass at strimzi sample using the spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/strimzi/01-kafka.yaml
+++ b/strimzi/01-kafka.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: kafka.strimzi.io/v1beta1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/strimzi/01-kafka.yaml
+++ b/strimzi/01-kafka.yaml
@@ -1,0 +1,64 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: Kafka
+metadata:
+  name: my-cluster
+  labels:
+    app: my-cluster
+spec:
+  kafka:
+    replicas: 3
+    resources:
+      requests:
+        memory: 2Gi
+        cpu: 500m
+      limits:
+        memory: 2Gi
+        cpu: "1"
+    jvmOptions:
+      -Xms: 1024m
+      -Xmx: 1024m
+    listeners:
+      plain: {}
+      tls:
+        authentication:
+          type: tls
+    authorization:
+      type: simple
+      superUsers:
+        - CN=my-connect
+        - my-connect
+        - ANONYMOUS
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+    storage:
+      type: ephemeral
+  zookeeper:
+    replicas: 3
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: "0.3"
+      limits:
+        memory: 1Gi
+        cpu: "0.5"
+    storage:
+      type: ephemeral
+  entityOperator:
+    topicOperator:
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: "0.1"
+        limits:
+          memory: 256Mi
+          cpu: "0.5"
+    userOperator:
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: "0.1"
+        limits:
+          memory: 256Mi
+          cpu: "0.5"

--- a/strimzi/02-kafka-topic.yaml
+++ b/strimzi/02-kafka-topic.yaml
@@ -1,0 +1,12 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaTopic
+metadata:
+  name: my-topic
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 3
+  replicas: 3
+  config:
+    retention.ms: 7200000
+    segment.bytes: 1073741824

--- a/strimzi/03-kafka-user.yaml
+++ b/strimzi/03-kafka-user.yaml
@@ -1,0 +1,49 @@
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-consumer
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: my-topic
+        operation: Read
+      - resource:
+          type: topic
+          name: my-topic
+        operation: Describe
+      - resource:
+          type: group
+          name: my-kafka-consumer
+        operation: Read
+---
+apiVersion: kafka.strimzi.io/v1beta1
+kind: KafkaUser
+metadata:
+  name: my-producer
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  authentication:
+    type: tls
+  authorization:
+    type: simple
+    acls:
+      - resource:
+          type: topic
+          name: my-topic
+        operation: Write
+      - resource:
+          type: topic
+          name: my-topic
+        operation: Create
+      - resource:
+          type: topic
+          name: my-topic
+        operation: Describe

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -24,7 +24,7 @@ spec:
   service:
     apiVersion: kafka.strimzi.io/v1beta1
     kind: Kafka
-    name: my-producer-cluster
+    name: my-cluster
     mappings:
       - name: hosts
         value: |-

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -1,0 +1,81 @@
+apiVersion: service.binding/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: kafka-producer-binding-user
+spec:
+  application:
+    apiVersion: app.stacks/v1beta1
+    kind: RuntimeComponent
+    name: kafka-producer
+  service:
+    apiVersion: v1beta1/kafka.strimzi.io
+    kind: KafkaUser
+    name: my-producer-user
+---
+apiVersion: service.binding/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: kafka-producer-binding-cluster
+spec:
+  application:
+    apiVersion: app.stacks/v1beta1
+    kind: RuntimeComponent
+    name: kafka-producer
+  service:
+    apiVersion: v1beta1/kafka.strimzi.io
+    kind: Kafka
+    name: my-producer-cluster
+    mappings:
+      - name: hosts
+        value: |-
+          {{- range .status.listeners -}}
+            {{- if and (eq .type "tls") (gt (len .addresses) 0) -}}
+              {{- with (index .addresses 0) -}}
+                {{ .host }}:{{ .port }}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+    env:
+      - name: BOOTSTRAP_SERVERS
+        key:  hosts      
+---
+  apiVersion: service.binding/v1alpha1
+  kind: ServiceBinding
+  metadata:
+    name: kafka-consumer-binding-user
+  spec:
+    application:
+      apiVersion: app.stacks/v1beta1
+      kind: RuntimeComponent
+      name: kafka-consumer
+    service:
+      apiVersion: v1beta1/kafka.strimzi.io
+      kind: KafkaUser
+      name: my-consumer-user
+  ---
+  apiVersion: service.binding/v1alpha1
+  kind: ServiceBinding
+  metadata:
+    name: kafka-consumer-binding-cluster
+  spec:
+    application:
+      apiVersion: app.stacks/v1beta1
+      kind: RuntimeComponent
+      name: kafka-consumer
+    service:
+      apiVersion: v1beta1/kafka.strimzi.io
+      kind: Kafka
+      name: my-consumer-cluster
+      mappings:
+        - name: hosts
+          value: |-
+            {{- range .status.listeners -}}
+              {{- if and (eq .type "tls") (gt (len .addresses) 0) -}}
+                {{- with (index .addresses 0) -}}
+                  {{ .host }}:{{ .port }}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+      env:
+        - name: BOOTSTRAP_SERVERS
+          key:  hosts      

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -8,7 +8,7 @@ spec:
     kind: RuntimeComponent
     name: kafka-producer
   service:
-    apiVersion: v1beta1/kafka.strimzi.io
+    apiVersion: kafka.strimzi.io/v1beta1
     kind: KafkaUser
     name: my-producer-user
 ---

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -63,7 +63,7 @@ spec:
       kind: RuntimeComponent
       name: kafka-consumer
     service:
-      apiVersion: v1beta1/kafka.strimzi.io
+      apiVersion: kafka.strimzi.io/v1beta1
       kind: Kafka
       name: my-consumer-cluster
       mappings:

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -65,7 +65,7 @@ spec:
     service:
       apiVersion: kafka.strimzi.io/v1beta1
       kind: Kafka
-      name: my-consumer-cluster
+    name: my-cluster
       mappings:
         - name: hosts
           value: |-

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -22,7 +22,7 @@ spec:
     kind: RuntimeComponent
     name: kafka-producer
   service:
-    apiVersion: v1beta1/kafka.strimzi.io
+    apiVersion: kafka.strimzi.io/v1beta1
     kind: Kafka
     name: my-producer-cluster
     mappings:

--- a/strimzi/04-service-binding.yaml
+++ b/strimzi/04-service-binding.yaml
@@ -49,7 +49,7 @@ spec:
       kind: RuntimeComponent
       name: kafka-consumer
     service:
-      apiVersion: v1beta1/kafka.strimzi.io
+      apiVersion: kafka.strimzi.io/v1beta1
       kind: KafkaUser
       name: my-consumer-user
   ---

--- a/strimzi/05-runtime-component.yaml
+++ b/strimzi/05-runtime-component.yaml
@@ -1,0 +1,71 @@
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: kafka-producer
+spec:
+  applicationImage: navidsh/hello-world-producer
+  env:
+    - name: KAFKA_SECRET_CA_CRT
+      valueFrom:
+        secretKeyRef:
+          name: kafka-producer-binding
+          key: KAFKA_SECRET_CA_CRT
+    - name: KAFKAUSER_SECRET_USER_CRT
+      valueFrom:
+        secretKeyRef:
+          name: kafka-producer-binding
+          key: KAFKAUSER_SECRET_USER_CRT
+    - name: KAFKAUSER_SECRET_USER_KEY
+      valueFrom:
+        secretKeyRef:
+          name: kafka-producer-binding
+          key: KAFKAUSER_SECRET_USER_KEY
+    - name: BOOTSTRAP_SERVERS
+      valueFrom:
+        secretKeyRef:
+          name: kafka-producer-binding
+          key: BOOTSTRAP_SERVERS
+    - name: TOPIC
+      value: my-topic
+    - name: NUMBER_OF_KEYS
+      value: "3"
+    - name: DELAY_MS
+      value: "1000"
+    - name: MESSAGE_COUNT
+      value: "1000000"
+---
+apiVersion: app.stacks/v1beta1
+kind: RuntimeComponent
+metadata:
+  name: kafka-consumer
+spec:
+  applicationImage: navidsh/hello-world-consumer
+  env:
+    - name: KAFKA_SECRET_CA_CRT
+      valueFrom:
+        secretKeyRef:
+          name: kafka-consumer-binding
+          key: KAFKA_SECRET_CA_CRT
+    - name: KAFKAUSER_SECRET_USER_CRT
+      valueFrom:
+        secretKeyRef:
+          name: kafka-consumer-binding
+          key: KAFKAUSER_SECRET_USER_CRT
+    - name: KAFKAUSER_SECRET_USER_KEY
+      valueFrom:
+        secretKeyRef:
+          name: kafka-consumer-binding
+          key: KAFKAUSER_SECRET_USER_KEY
+    - name: BOOTSTRAP_SERVERS
+      valueFrom:
+        secretKeyRef:
+          name: kafka-consumer-binding
+          key: BOOTSTRAP_SERVERS
+    - name: TOPIC
+      value: my-topic
+    - name: GROUP_ID
+      value: my-kafka-consumer
+    - name: LOG_LEVEL
+      value: "INFO"
+    - name: MESSAGE_COUNT
+      value: "1000000"

--- a/strimzi/README.md
+++ b/strimzi/README.md
@@ -1,0 +1,152 @@
+# Binding Event-driven Applications to an In-cluster Operator Managed Kafka Cluster
+
+## Status
+
+This sample is currently **EXPERIMENTAL**, which means that not all pieces are available in the community today.
+
+
+## Introduction
+
+This scenario illustrates binding two event-driven applications to an in-cluster Operator Managed Kafka cluster using the Service Binding Specification. 
+
+## Actions to Perform by Users in 2 Roles
+
+In this example there are 2 roles:
+
+* Cluster Admin - Installs the operators to the cluster
+* Application Developer - Creates a Kafka cluster, creates required Kafka resources, imports applications and creates a request to bind the applications to the Kafka cluster and the Kafka resources.
+
+### Cluster Admin
+
+The cluster admin needs to install 3 operators into the cluster:
+
+* Service Binding Operator
+* Strimzi Operator
+* Runtime Component Operator
+
+#### Install the Service Binding Operator
+
+Navigate to the **Operator** → **OperatorHub** in the OpenShift console. From the `Developer Tools` category, select the `Service Binding Operator` operator and install a `alpha` version. This would install the `ServiceBindingRequest` *custom resource definition* (CRD) in the cluster.
+
+#### Install the Strimzi Operator
+
+Create the following `OperatorSource`:
+
+```console
+cat <<EOS |kubectl apply -f -
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: strimzi-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: navidsh
+  displayName: "Bindable Strimzi Operators"
+EOS
+```
+
+Once the `OperatorSource` is created, the "bindable" Strimzi Operator will be available to install from OperatorHub catalog in OpenShift console.
+
+Then, navigate to the **Operator** → **OperatorHub** in the OpenShift console. Select **Strimzi** operator labelled as "custom" (not "Community") and install on the cluster.
+
+#### Install the Runtime Component Operator
+
+Navigate to the **Operator** → **OperatorHub** in the OpenShift console. Select the `Runtime Component Operator` operator and install a `beta` version. This would install the `RuntimeComponent` *custom resource definition* (CRD) in the cluster.
+
+### Application Developer
+
+#### Create a namespace called `service-binding-demo`
+
+The application and the service instance needs a namespace to live in so let's create one for them:
+
+```console
+cat <<EOS |kubectl apply -f -
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: service-binding-demo
+EOS
+```
+
+#### Create a Kafka cluster
+
+Now we use the Strimzi Operator that the cluster admin has installed. To create a Kafka cluster instance, just create a [`Kafka` custom resource](./01-kafka.yaml) in the `service-binding-demo` namespace called `my-cluster`:
+
+```console
+oc apply -f 01-kafka.yaml
+```
+
+It takes usually a few seconds to spin-up a new Kafka cluster. You can check the status in the custom resources:
+
+```console
+oc get kafka my-cluster -o yaml
+```
+
+This creates a Kafka cluster with a `tls` listener with mutual TLS authentication.
+
+#### Create a Kafka Topic
+
+To create a Kafka Topic, apply the [`KafkaTopic` custom resource](./02-kafka-topic.yaml) in the `service-binding-demo` namespace:
+
+```console
+oc apply -f 02-kafka-topic.yaml
+```
+
+Check the created custom resource:
+
+```console
+oc get kt my-topic
+```
+
+#### Create Kafka Users
+
+To create Kafka Users, one user for producer application and one user for consumer application, apply the [`KafkaUser` custom resources](./03-kafka-user.yaml) in the `service-binding-demo` namespace:
+
+```console
+oc apply -f 03-kafka-user.yaml
+```
+
+Check the created custom resource:
+
+```console
+oc get kafkausers
+```
+
+#### Create a Service Binding
+
+In order to bind the application to the Kafka resources, create [`ServiceBinding` custom resources](./04-service-binding.yaml) in the `service-binding-demo` namespace:
+
+```console
+oc apply -f 04-service-binding.yaml
+```
+
+#### Deploy the Producer and the Consumer Applications
+
+To deploy the producer and the consumer applications, create [`RuntimeComponent` resources](./05-runtime-component.yaml) in the `service-binding-demo` namespace:
+
+```console
+oc apply -f 05-runtime-component.yaml
+```
+
+The Runtime Component Operator will create `Deployment` resources and defines binding information as environment variables for the application containers with values from the binding secret created by the Service Binding Operator.
+
+#### View Messages
+
+To see messages sent by the producer application, run:
+
+```console
+oc logs -n service-binding-demo -f $(oc get pods -l app=kafka-producer -o name)
+```
+
+You can press <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop viewing the log messages.
+
+Similarly, use the following command to see messages received by the consumer application:
+
+```console
+oc logs -n service-binding-demo -f $(oc get pods -l app=kafka-consumer -o name)
+```
+


### PR DESCRIPTION
Moving the strimzi sample off the main `spec` repo.   Converted to use the spec's `ServiceBinding` CR.   Things aren't actually working because SBO needs to implement parts of the spec, but at least it's more representative of what the sample should look like.

Signed-off-by: Arthur De Magalhaes <ademagalhaes@gmail.com>